### PR TITLE
Update README and configuration for monthly schedule change to 6 AM UTC on the 1st of each month

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This AWS Lambda function automatically updates multiple YNAB category targets ba
 - Updates multiple YNAB category targets with the new rate
 - Maintains a history of updates in category notes
 - Sends detailed email notifications for successful updates and skips
-- Runs automatically on the 20th of each month
+- Runs automatically at 6 AM UTC on the 1st of each month
 - Secure credential management using AWS Systems Manager Parameter Store with direct fetching (no caching)
 - Comprehensive test coverage
 - CI/CD pipeline with GitHub Actions
@@ -133,7 +133,7 @@ This AWS Lambda function automatically updates multiple YNAB category targets ba
 ## Configuration
 
 The Lambda function is configured to:
-- Run at midnight (UTC) on the 20th of each month (as INE typically publishes the IPC update around the 14th)
+- Run at 6 AM UTC on the 1st of each month (as INE typically publishes the IPC update around the 14th)
 - Use 128MB of memory
 - Timeout after 30 seconds
 - Use Python 3.11 runtime

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -64,8 +64,8 @@ Resources:
           Properties:
             Schedule: !If 
               - IsMonthlyMode
-              - cron(0 0 20 * ? *)  # Run at midnight on the 20th of each month
-              - cron(0 0 20 1 ? *)  # Run at midnight on January 20th
+              - cron(0 6 1 * ? *)  # Run at 6 AM UTC on the 1st of each month
+              - cron(0 6 1 1 ? *)  # Run at 6 AM UTC on January 1st
             Name: !Sub "${AWS::StackName}-${UpdateMode}-update"
             Description: !Sub "Updates YNAB target with ${UpdateMode} IPC rate"
             Enabled: true

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -456,7 +456,7 @@ def test_lambda_handler_yearly_wrong_month():
         # Mock current date as March
         mock_date = MagicMock()
         mock_date.month = 3
-        mock_date.isoformat.return_value = '2024-03-20'
+        mock_date.isoformat.return_value = '2024-03-01'
         mock_datetime.now.return_value = mock_date
 
         result = lambda_handler({}, None)
@@ -486,7 +486,7 @@ def test_lambda_handler_yearly_correct_month():
         # Mock current date as January
         mock_date = MagicMock()
         mock_date.month = 1
-        mock_date.isoformat.return_value = '2024-01-20'
+        mock_date.isoformat.return_value = '2024-01-01'
         mock_datetime.now.return_value = mock_date
 
         # Mock IPC rate and update response


### PR DESCRIPTION
- Modify README to reflect the new schedule for automatic updates
- Update CloudFormation template to change the cron expression for the Lambda function
- Adjust test cases to align with the new schedule 